### PR TITLE
Remove livereloading for manifest v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,8 @@ These are added to the manifest:
 - Livereload assets are added to web accessible resources.
 - Background page becomes persistent.
 
+Live reloading is not compatible with Manifest v3.
+
 ## Caveats
 
 If you don't use dynamic import skip this section.

--- a/lib/WexExtManifestPlugin.js
+++ b/lib/WexExtManifestPlugin.js
@@ -71,7 +71,7 @@ class WexExtManifestPlugin {
             await fse.move(tmpPath, output)
           }
           
-          if (argv.livereload) {
+          if (argv.livereload && finalManifest.manifest_version === 2) {
             // modify manifest before emitting file
             liverreloadModify(finalManifest)
             
@@ -150,22 +150,10 @@ function liverreloadModify(manifest) {
   }
   manifest.permissions = [...new Set([
     ...manifest.permissions,
-    manifest.version === 2 && "*://neutrino-webextension.reloads/*",
+    "*://neutrino-webextension.reloads/*",
     "webRequest",
     "webRequestBlocking",
     // remove history
     "browsingData"
   ])]
-
-  if (manifest.version === 3) {
-    if (!manifest.host_permissions) {
-      manifest.host_permissions = []
-    }
-    manifest.host_permissions = [
-      ...new Set([
-        ...manifest.host_permissions,
-        "*://neutrino-webextension.reloads/*"
-      ])
-    ]
-  }
 }

--- a/test/manifestV2/src/manifest/chrome.manifest.json
+++ b/test/manifestV2/src/manifest/chrome.manifest.json
@@ -1,3 +1,5 @@
 {
+  "background": {
     "persistent": false
+  }
 }


### PR DESCRIPTION
Following #24, I didn't test livereloading in v3. Due to [changes in how network requests are working](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/#modifying-network-requests) the livereloading is not working properly.

For now I'm blocking the livereloading option to manifest v2 only. I tested it works well.